### PR TITLE
Fix inkscape DPI detection

### DIFF
--- a/host/shiver/src/main/java/dk/osaa/psaw/job/SvgLoader.java
+++ b/host/shiver/src/main/java/dk/osaa/psaw/job/SvgLoader.java
@@ -75,7 +75,7 @@ public class SvgLoader {
 				long major = Long.parseLong(majorMinor.group(1));
 				long minor = Long.parseLong(majorMinor.group(2));
 				log.fine("Parsed inkscape version: "+major+"."+minor);
-				if (major == 0 && minor < 91) {
+				if (major == 0 && minor <= 91) {
 					dpi = 90;
 				}
 			}


### PR DESCRIPTION
According to http://wiki.inkscape.org/wiki/index.php/Units_In_Inkscape, Inkscape versions up to and including 0.91 uses 90 DPI. Fix detection.